### PR TITLE
Fixes import data from DS so that src_url and src_type are no longer null

### DIFF
--- a/api/incidents/incidentsModel.js
+++ b/api/incidents/incidentsModel.js
@@ -27,8 +27,10 @@ async function createIncident(incident) {
   const incidentID = await db('incidents').insert(newIncident, 'incident_id');
   await Sources.createSource(incident.src, incidentID[0]);
 
-  for (let i = 0; i < tagList.length; i++) {
-    await Tags.createTags(tagList[i], incidentID[0]);
+  if (tagList[0] != '') {
+    for (let i = 0; i < tagList.length; i++) {
+      await Tags.createTags(tagList[i], incidentID[0]);
+    }
   }
   return { message: 'Success!' };
 }

--- a/api/incidents/incidentsRouter.js
+++ b/api/incidents/incidentsRouter.js
@@ -408,6 +408,7 @@ router.get('/tags/:incidentID', (req, res) => {
 router.get('/fetchfromds', (req, res) => {
   let incidents = [];
   let incidentList = [];
+
   axios
     .get(process.env.DS_API_URL)
     .then((response) => {
@@ -420,8 +421,8 @@ router.get('/fetchfromds', (req, res) => {
     .finally(async () => {
       incidents.forEach((incident) => {
         if (incident.city != null) {
-          let src = [];
           let sources = incident.src;
+          incident.src = [];
 
           sources.forEach((source) => {
             let s = { src_url: '', src_type: '' };
@@ -489,12 +490,11 @@ router.get('/fetchfromds', (req, res) => {
             }
 
             s.src_type = src_type;
-            src.push(s);
+            incident.src.push(s);
           });
           incidentList.push(incident);
         }
       });
-
       for (let i = 0; i < incidentList.length; i++) {
         await Incidents.createIncident(incidentList[i]);
       }

--- a/data/migrations/20200625220949_create-profile.js
+++ b/data/migrations/20200625220949_create-profile.js
@@ -13,7 +13,7 @@ exports.up = function (knex) {
     })
     .createTable('sources', (sources) => {
       sources.increments('src_id').notNullable().unique().primary();
-      sources.string('src_url');
+      sources.string('src_url', 10000);
       sources.string('src_type');
     })
     .createTable('type_of_force', (type_of_force) => {


### PR DESCRIPTION
# Description
When importing data from DS fixes the issue where the source url and source type were set to null instead of the actual values passed by the DS API. 

## Type of change
Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Change Status
- Complete, tested, ready to review and merge

# How Has This Been Tested?
- Jest
- Postman

